### PR TITLE
Change youtube regexp so videos can start from a certain time

### DIFF
--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,7 +1,7 @@
 class Song < ApplicationRecord
 	belongs_to :user
 
-	VIDEO_REGEXP = /\A(http)?(s)?(:\/\/)?(www\.youtube\.com\/watch\?v=)|(youtu\.be\/)(.*)\z/
+	VIDEO_REGEXP = /\A(http)?(s)?(:\/\/)?(www\.youtube\.com\/watch\?(time_continue=\d+\&)?(v=))|(youtu\.be\/)(.*)\z/
 
   validates :title, presence: true, length: { maximum: 50 }, uniqueness: { scope: :user_id }
 	validates :artist, length: { maximum: 50 }

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -95,6 +95,11 @@ RSpec.describe Song, type: :model do
       it { is_expected.to be_valid }
     end
 
+    context 'continue属性がリンクに入っても大丈夫' do
+      let(:video) { 'https://www.youtube.com/watch?time_continue=1&v=6OHEAbjBtlY' }
+      it { is_expected.to be_valid }
+    end
+
     context '正しくない形式' do
       let(:video) { 'https://google.com/' }
       it { is_expected.to be_invalid }


### PR DESCRIPTION
Just as the title suggests.
Double check the link format just in case.

Linked to Issue #65 