### PR TITLE
Login directly with oauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'friendly_id', '~> 5.1.0'
 gem 'database_cleaner', '~> 1.6.0'
 gem 'uglifier'
 
+gem 'email_validator'
 gem "acts_as_list", "~> 1.0"
 
 gem 'pdfkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
+    email_validator (2.2.3)
+      activemodel
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
@@ -356,6 +358,7 @@ DEPENDENCIES
   carrierwave (~> 2.1)
   database_cleaner (~> 1.6.0)
   devise
+  email_validator
   factory_bot_rails
   figaro
   font-awesome-rails

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -23,7 +23,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user
     else
       session["devise.user_attributes"] = @user.attributes
-      redirect_to new_user_registration_url
+      @user.save!
+      sign_in_and_redirect @user
     end
   end
 end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,7 +5,6 @@ class RegistrationsController < Devise::RegistrationsController
 		resource.update_without_password(params)
 	end
 
-	# TODO: Let the user sign in with their e-mail and password as well, not just omniauth
 	private
 
 	def sign_up_params

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,12 @@
 module UsersHelper
   def get_user_image
-    @user.user_image ? @user.user_image : 'user_black_logo.jpg'
+    # TODO: Check Facebook Developer's settings and see what can be done to fix this
+    if @user.user_image.present? && !!@user.user_image.match(/^http:/)
+      user_image = @user.user_image.gsub(/^http/, "https")
+    else
+      user_image = @user.user_image
+    end
+
+    @user.user_image ? user_image : 'user_black_logo.jpg'
   end
 end

--- a/db/migrate/20201103060602_devise_create_users.rb
+++ b/db/migrate/20201103060602_devise_create_users.rb
@@ -36,7 +36,9 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
+    # We make sure the email index is not unique here because
+    # oauth doesn't save the user's email to the database.
+    add_index :users, :email,                unique: false
     add_index :users, :reset_password_token, unique: true
     add_index :users, :confirmation_token,   unique: true
     add_index :users, :unlock_token,         unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2020_11_18_102204) do
     t.string "username"
     t.string "slug"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email"], name: "index_users_on_email"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true


### PR DESCRIPTION
Prior to this pull request, user were already able to register/login with omniauth. This fix, however, will automate the process and guides the user directly to their profile page.

Since they don't need their email or a password to do this, I removed `:validatable` from the `User` model. For this reason, there are custom validations for these attributes if the user is not registering with omniauth:
1. Email (Validated with the `email_validator` gem)
2. Password (skipped by [overriding a Devise method](https://stackoverflow.com/questions/9210844/skip-email-validation-in-devise))

Although I'm not taking the user's email and saving it to the database, it's possible.
For example, Google's `auth` hash stores it here:
`auth["extra"]["raw_info"]["email"]`

Although it's possible to have a user register and link sns accounts to their account later, I'm taking this approach for now with this project.